### PR TITLE
Add cert option to Actual dependency

### DIFF
--- a/config/config.yml.sample
+++ b/config/config.yml.sample
@@ -16,3 +16,5 @@ account_mappings:
   checking: "B2F7DF53-6A9C-42CF-B091-9129A3A9B528"
   credit_card: "C3D8F25A-9C7D-4C9B-8589-8A3790C03B2D"
 log_level: INFO
+# Path to the certificate file (optional)
+actual_cert: "/path/to/cert.pem"

--- a/core/config.py
+++ b/core/config.py
@@ -14,6 +14,7 @@ class Settings(BaseSettings):
     actual_backup_payee: str
     account_mappings: Dict[str, str]
     log_level: str = "INFO"
+    actual_cert: str = None  # Path to the certificate file (optional)
 
     class Config:
         env_file = ".env"

--- a/services/actual_service.py
+++ b/services/actual_service.py
@@ -27,6 +27,7 @@ class ActualService:
             settings.actual_url,
             password=settings.actual_password,
             file=settings.actual_budget,
+            cert=settings.actual_cert
         ) as actual:
             for tx in transactions:
                 # Map account name to Actual account ID

--- a/services/actual_service.py
+++ b/services/actual_service.py
@@ -23,12 +23,15 @@ class ActualService:
         transaction_info_list = []
         submitted_transactions = []
 
-        with Actual(
-            settings.actual_url,
-            password=settings.actual_password,
-            file=settings.actual_budget,
-            cert=settings.actual_cert
-        ) as actual:
+        actual_kwargs = {
+            "url": settings.actual_url,
+            "password": settings.actual_password,
+            "file": settings.actual_budget,
+        }
+        if settings.actual_cert:
+            actual_kwargs["cert"] = settings.actual_cert
+
+        with Actual(**actual_kwargs) as actual:
             for tx in transactions:
                 # Map account name to Actual account ID
                 account_id = settings.account_mappings.get(tx.account, settings.actual_default_account_id)


### PR DESCRIPTION
Add support for 'cert' option in Actual dependency.

* **config/config.yml.sample**
  - Add a new setting `actual_cert` for the certificate path.
  - Place the new setting above the `log_level` setting.
  - Make the config option optional.

* **core/config.py**
  - Add a new field `actual_cert` to the `Settings` class.
  - Make the config option optional.

* **services/actual_service.py**
  - Add `cert=settings.actual_cert` to the `Actual` class instantiation at line 29.
  - Make the config option optional.

